### PR TITLE
fixed timer inflation by adding duration instead of end-start

### DIFF
--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -274,6 +274,7 @@ const Timer = ({ onGuardChange }) => {
         user_id: userId,
         started_at: startedAt.toISOString(),
         ended_at: endedAt.toISOString(),
+        duration_seconds: durationSeconds,
         note: note.trim(),
       })
       .select()


### PR DESCRIPTION
fixed the timer inflation by adding duration instead of end-start. closes the [timer pausing leads to inflation](https://github.com/locknclock/locknclock.github.io/issues/2) issue.